### PR TITLE
Fix base URL fallback in tasks API

### DIFF
--- a/client/src/api/tasks.js
+++ b/client/src/api/tasks.js
@@ -1,5 +1,5 @@
 //client  /src/api/tasks.js
-const BASE = import.meta.env.VITE_API_URL;
+const BASE = import.meta.env.VITE_API_URL || '';
 
 export const api = {
 


### PR DESCRIPTION
## Summary
- provide a default value for `BASE` in the client API so missing env var doesn't produce invalid URLs
- reverted change in the deprecated `TaskCard` component

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fe13bfebc832c9a72c376e32e50c6